### PR TITLE
Better classifiers handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+/classifiers/

--- a/spe/spe.py
+++ b/spe/spe.py
@@ -6,6 +6,10 @@ import numpy as np
 from fasttext.FastText import _FastText
 
 
+class ClassifierNotFound(Exception):
+    pass
+
+
 def spe_sentence(
     input_sentence: Sequence[str],
     classifiers: Sequence[_FastText],
@@ -57,7 +61,7 @@ def load_classifiers() -> List[_FastText]:
     ]
 
     if len(classifier_files) == 0:
-        raise Exception(
+        raise ClassifierNotFound(
             "ERROR: There were not fasttext classifiers located in the classifiers folder"
         )
 

--- a/spe/spe.py
+++ b/spe/spe.py
@@ -2,11 +2,14 @@
 The Semantics Preserving Encoder source code.
 """
 import os
+import pathlib
 from typing import List, Sequence
 
 import fasttext
 import numpy as np
 from fasttext.FastText import _FastText
+
+from utils import download_default_classifiers
 
 
 class ClassifierNotFound(Exception):
@@ -53,7 +56,16 @@ def load_classifiers() -> List[_FastText]:
 
     :return: list of loaded fastText classifiers
     """
-    classifiers_folder_path = os.path.join(os.path.dirname(__file__), 'classifiers')
+    classifiers_folder_path = pathlib.Path("./classifiers")
+
+    if (
+        not classifiers_folder_path.exists()
+        or len(list(classifiers_folder_path.glob("*.ftz"))) == 0
+    ):
+        print("No classifiers found.")
+        classifiers_folder_path.mkdir(exist_ok=True)
+        # This tries to download the default classifiers zip archive.
+        download_default_classifiers()
 
     classifiers = []
     classifier_files = [
@@ -63,6 +75,7 @@ def load_classifiers() -> List[_FastText]:
         and f.endswith(".ftz")
     ]
 
+    # If we failed to download default classifiers raise a classifier not found error.
     if len(classifier_files) == 0:
         raise ClassifierNotFound(
             "ERROR: There were not fasttext classifiers located in the classifiers"

--- a/spe/spe.py
+++ b/spe/spe.py
@@ -1,10 +1,16 @@
 import os
+from typing import List, Sequence
 
 import fasttext
 import numpy as np
+from fasttext import _FastText
 
 
-def spe_sentence(input_sentence, classifiers, vector_dimension):
+def spe_sentence(
+    input_sentence: Sequence[str],
+    classifiers: Sequence[_FastText],
+    vector_dimension: int,
+) -> np.ndarray:
     """
     Processes the input sentence for each classifier into an averaged vector
     of given dimensions. This process is described in detail in paper
@@ -34,7 +40,7 @@ def spe_sentence(input_sentence, classifiers, vector_dimension):
     return final_average_vector
 
 
-def load_classifiers():
+def load_classifiers() -> List[_FastText]:
     """
     Loads all the fastText classifiers that are in classifiers_folder_path.
 
@@ -71,7 +77,7 @@ def load_classifiers():
     return classifiers
 
 
-def spe(input_sentences, vector_dimension=10):
+def spe(input_sentences: Sequence[str], vector_dimension: int = 10) -> List[np.ndarray]:
     """
     Processes the list of input sentences into a corresponding array of vectors.
 

--- a/spe/spe.py
+++ b/spe/spe.py
@@ -1,3 +1,6 @@
+"""
+The Semantics Preserving Encoder source code.
+"""
 import os
 from typing import List, Sequence
 
@@ -27,7 +30,7 @@ def spe_sentence(
 
     """
 
-    max_vector_size = min([len(i.get_sentence_vector("Test")) for i in classifiers])
+    max_vector_size = min(len(i.get_sentence_vector("Test")) for i in classifiers)
     if vector_dimension > max_vector_size:
         raise Exception(
             "ERROR: Vector dimension is higher than the model dimension, which is: "
@@ -62,7 +65,8 @@ def load_classifiers() -> List[_FastText]:
 
     if len(classifier_files) == 0:
         raise ClassifierNotFound(
-            "ERROR: There were not fasttext classifiers located in the classifiers folder"
+            "ERROR: There were not fasttext classifiers located in the classifiers"
+            " folder"
         )
 
     try:

--- a/spe/spe.py
+++ b/spe/spe.py
@@ -56,7 +56,7 @@ def load_classifiers() -> List[_FastText]:
 
     :return: list of loaded fastText classifiers
     """
-    classifiers_folder_path = pathlib.Path("./classifiers")
+    classifiers_folder_path = pathlib.Path("./spe_classifiers")
 
     if (
         not classifiers_folder_path.exists()

--- a/spe/spe.py
+++ b/spe/spe.py
@@ -1,21 +1,28 @@
-import numpy as np
-import fasttext
 import os
+
+import fasttext
+import numpy as np
+
 
 def spe_sentence(input_sentence, classifiers, vector_dimension):
     """
-    Processes the input sentence for each classifier into an averaged vector of given dimensions.
-    This process is described in detail in paper https://arxiv.org/abs/2211.04205.
+    Processes the input sentence for each classifier into an averaged vector
+    of given dimensions. This process is described in detail in paper
+    https://arxiv.org/abs/2211.04205.
 
     :param input_sentence: sentence as a string
     :param classifiers: list of loaded classifiers
     :param vector_dimension: dimension of the averaged output vector as int
     :return: averaged output vector for given sentence
+
     """
 
     max_vector_size = min([len(i.get_sentence_vector("Test")) for i in classifiers])
     if vector_dimension > max_vector_size:
-        raise Exception("ERROR: Vector dimension is higher than the model dimension, which is: " + str(max_vector_size))
+        raise Exception(
+            "ERROR: Vector dimension is higher than the model dimension, which is: "
+            + str(max_vector_size)
+        )
 
     averaged_vector_arr = np.zeros(shape=(len(classifiers), vector_dimension))
     # get all vectors from classifiers and put them in an array
@@ -36,15 +43,22 @@ def load_classifiers():
     classifiers_folder_path = os.path.join(os.path.dirname(__file__), 'classifiers')
 
     classifiers = []
-    classifier_files = [f for f in os.listdir(classifiers_folder_path) if
-                        os.path.isfile(os.path.join(classifiers_folder_path, f)) and f.endswith(".ftz")]
+    classifier_files = [
+        f
+        for f in os.listdir(classifiers_folder_path)
+        if os.path.isfile(os.path.join(classifiers_folder_path, f))
+        and f.endswith(".ftz")
+    ]
 
     if len(classifier_files) == 0:
-        raise Exception("ERROR: There were not fasttext classifiers located in the classifiers folder")
+        raise Exception(
+            "ERROR: There were not fasttext classifiers located in the classifiers folder"
+        )
 
     try:
-        # silence the deprecation warnings as the package does not properly use the python 'warnings' package
-        # see https://github.com/facebookresearch/fastText/issues/1056
+        # silence the deprecation warnings as the package does not properly use
+        # the python 'warnings' package see
+        # https://github.com/facebookresearch/fastText/issues/1056
         fasttext.FastText.eprint = lambda *args, **kwargs: None
 
         for name in classifier_files:
@@ -57,12 +71,13 @@ def load_classifiers():
     return classifiers
 
 
-def spe(input_sentences, vector_dimension = 10):
+def spe(input_sentences, vector_dimension=10):
     """
     Processes the list of input sentences into a corresponding array of vectors.
 
     :param input_sentences: list of input sentences as list of strings
-    :param vector_dimension (optional): dimension of the output sentence vectors as int, default value is 10
+    :param vector_dimension (optional): dimension of the output sentence vectors as int,
+        default value is 10
     :return: array of vector sentences, one for each sentence
     """
     classifiers = load_classifiers()
@@ -73,10 +88,11 @@ def spe(input_sentences, vector_dimension = 10):
     return vector_sentences
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     input_sentences = [
-    "The quick brown fox jumps over the lazy dog.",
-    "I am a sentence for which I would like to get its embedding"]
+        "The quick brown fox jumps over the lazy dog.",
+        "I am a sentence for which I would like to get its embedding",
+    ]
     output = spe(input_sentences, 10)
     print("SPE output:")
     print(output)

--- a/spe/spe.py
+++ b/spe/spe.py
@@ -3,7 +3,7 @@ from typing import List, Sequence
 
 import fasttext
 import numpy as np
-from fasttext import _FastText
+from fasttext.FastText import _FastText
 
 
 def spe_sentence(
@@ -71,7 +71,7 @@ def load_classifiers() -> List[_FastText]:
             classifiers.append(
                 fasttext.load_model(os.path.join(classifiers_folder_path, name))
             )
-    except:
+    except Exception as _:
         pass
 
     return classifiers

--- a/spe/utils.py
+++ b/spe/utils.py
@@ -7,7 +7,7 @@ import zipfile
 default_classifiers_url = "https://data.ciirc.cvut.cz/public/projects/2022PreservingSemanticsEncoder/default_classifiers.zip"
 
 
-def download_default_classifiers(extract_to=pathlib.Path("./classifiers")):
+def download_default_classifiers(extract_to=pathlib.Path("./spe_classifiers")):
     print("Downloading default classifiers.")
     try:
         with urllib.request.urlopen(

--- a/spe/utils.py
+++ b/spe/utils.py
@@ -7,7 +7,9 @@ import zipfile
 default_classifiers_url = "https://data.ciirc.cvut.cz/public/projects/2022PreservingSemanticsEncoder/default_classifiers.zip"
 
 
-def download_default_classifiers(extract_to=pathlib.Path("./spe_classifiers")):
+def download_default_classifiers(
+    extract_to: pathlib.Path = pathlib.Path("./spe_classifiers"),
+):
     print("Downloading default classifiers.")
     try:
         with urllib.request.urlopen(

--- a/spe/utils.py
+++ b/spe/utils.py
@@ -1,0 +1,25 @@
+import io
+import pathlib
+import urllib.error
+import urllib.request
+import zipfile
+
+default_classifiers_url = "https://data.ciirc.cvut.cz/public/projects/2022PreservingSemanticsEncoder/default_classifiers.zip"
+
+
+def download_default_classifiers(extract_to=pathlib.Path("./classifiers")):
+    print("Downloading default classifiers.")
+    try:
+        with urllib.request.urlopen(
+            default_classifiers_url
+        ) as http_response, zipfile.ZipFile(
+            io.BytesIO(http_response.read())
+        ) as zip_file:
+            zip_file.extractall(path=extract_to)
+        print("Done.")
+
+    except urllib.error.URLError as e:
+        print(f"Error opening default classifiers URL: {e}")
+
+    except zipfile.BadZipFile as e:
+        print(f"Error downloading default classifiers zip archive: {e}")


### PR DESCRIPTION
This PR decouples the default classifiers from the library itself. For now, all the default classifiers are bundled in the Python package, which makes it a 12MB package with only 100 lines of code. 

Instead of having the `classifiers` folder inside the source code, it will be in the directory where the code calling the library is being run. This means a user can easily delete or add new classifiers inside that folder, whereas there is no such mechanism for now. The library will test whether a `spe_classifiers` folder is present and has some classifiers. If not, it will create it and download the default classifiers that I uploaded on the CIIRC server https://data.ciirc.cvut.cz/public/projects/2022PreservingSemanticsEncoder/. 

I also applied some black formatting, added method typing, and fixed a few things in the code.


The flow of action for downloading classifiers is simply: 

![Untitled Diagram](https://user-images.githubusercontent.com/15968394/201603381-1b40111e-0672-4001-8c57-a7b4512d26c1.svg)

